### PR TITLE
Fix code scanning alert no. 705: Unsigned difference expression compared to zero

### DIFF
--- a/deps/ada/ada.h
+++ b/deps/ada/ada.h
@@ -6710,7 +6710,7 @@ inline bool url_aggregator::has_non_empty_username() const noexcept {
 
 inline bool url_aggregator::has_non_empty_password() const noexcept {
   ada_log("url_aggregator::has_non_empty_password");
-  return components.host_start - components.username_end > 0;
+  return static_cast<int64_t>(components.host_start) - static_cast<int64_t>(components.username_end) > 0;
 }
 
 inline bool url_aggregator::has_password() const noexcept {


### PR DESCRIPTION
Fixes [https://github.com/akadev1/node/security/code-scanning/705](https://github.com/akadev1/node/security/code-scanning/705)

To fix the problem, we need to cast the result of the subtraction to a signed type before performing the comparison. This ensures that the comparison behaves as intended, even if `components.host_start` is less than `components.username_end`.

- **General fix:** Cast the result of the subtraction to a signed type before performing the comparison.
- **Detailed fix:** In the file `deps/ada/ada.h`, on line 6713, cast the result of `components.host_start - components.username_end` to a signed type (e.g., `int64_t`) before comparing it to `0`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
